### PR TITLE
Update image digest to sha256:d87549453c2933d53893c20d7f2ea5d1b23ad14bf25c4a8d34adf6b12d180828

### DIFF
--- a/envs/staging/values.yaml
+++ b/envs/staging/values.yaml
@@ -1,3 +1,3 @@
 image:
   repository: cjmak0/test-messenger
-  digest: sha256:a72e73d7815e80e395ad24f5a095b0a6f41f4daa37bcdbefb9c32f3f83644e16
+  digest: sha256:d87549453c2933d53893c20d7f2ea5d1b23ad14bf25c4a8d34adf6b12d180828


### PR DESCRIPTION
This PR updates the Helm deployment to use image:\ncjmak0/test-messenger@sha256:d87549453c2933d53893c20d7f2ea5d1b23ad14bf25c4a8d34adf6b12d180828