### PR TITLE
Update image digest for staging release

### DIFF
--- a/envs/staging/values.yaml
+++ b/envs/staging/values.yaml
@@ -1,3 +1,3 @@
 image:
   repository: cjmak0/test-messenger
-  digest: sha256:a72e73d7815e80e395ad24f5a095b0a6f41f4daa37bcdbefb9c32f3f83644e16
+  digest: sha256:d0c75057e0b4b52ade67041c31fdeb8f7a6412ec1794fb63e139e205614f3a6c


### PR DESCRIPTION
This PR updates the Helm deployment to use image:\ncjmak0/test-messenger@sha256:d0c75057e0b4b52ade67041c31fdeb8f7a6412ec1794fb63e139e205614f3a6c